### PR TITLE
add .env in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+.env
 .DS_Store


### PR DESCRIPTION
I added .env in your .gitignore file, because your .env file will contain sensitive data, like passwords when you'll use a database. 